### PR TITLE
Add vision kill switch and update dashboard

### DIFF
--- a/src/main/deploy/elastic-layout.json
+++ b/src/main/deploy/elastic-layout.json
@@ -86,16 +86,29 @@
             }
           },
           {
-            "title": "primary-raw",
+            "title": "Hub Camera",
             "x": 0.0,
             "y": 0.0,
             "width": 448.0,
             "height": 384.0,
             "type": "Camera Stream",
             "properties": {
-              "topic": "/CameraPublisher/primary-raw",
+              "topic": "/CameraPublisher/photonvision_Port_1182_Output_MJPEG_Server",
               "period": 0.06,
               "rotation_turns": 0
+            }
+          },
+          {
+            "title": "Enable Vision Localization",
+            "x": 448.0,
+            "y": 384.0,
+            "width": 256.0,
+            "height": 128.0,
+            "type": "Toggle Switch",
+            "properties": {
+              "topic": "/SmartDashboard/Vision/Enabled",
+              "period": 0.06,
+              "data_type": "boolean"
             }
           }
         ]

--- a/src/main/java/frc/robot/subsystems/VisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/VisionSubsystem.java
@@ -10,6 +10,7 @@ import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 import org.photonvision.EstimatedRobotPose;
@@ -143,6 +144,8 @@ public class VisionSubsystem extends SubsystemBase {
     public VisionSubsystem(SwerveSubsystem swerveSubsystem) {
         this.swerveSubsystem = swerveSubsystem;
 
+        SmartDashboard.putBoolean("Vision/Enabled", true);
+
         for (VisionConstants.CameraProperties cameraProperties : VisionConstants.CAMERAS) {
             cameras.add(new Camera(cameraProperties));
         }
@@ -159,6 +162,10 @@ public class VisionSubsystem extends SubsystemBase {
 
     @Override
     public void periodic() {
+        if (!SmartDashboard.getBoolean(("Vision/Enabled"), true)) {
+            return;
+        }
+
         for (Camera camera: cameras) {
             Optional<PoseEstimate> cameraEstimate = camera.estimatePose();
 


### PR DESCRIPTION
Allows the driver to disable vision pose estimates if there is an issue with the cameras. Also fixes the camera stream to work outside of simulation.

Closes #20
Closes #27  